### PR TITLE
README 文件展示格式错乱

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ ESA Cabin用于解决模块间类冲突。要解决的问题是，当一个应�
 + 在xxx-cabin的pom中加入cabin-module-maven-plugin插件，并配置相关信息
 <br>
 下面用ESA RPC举例讲解如何打包：
+
 + esa-rpc-cabin (会传递三方依赖)
+
 ```xml
 <dependencies>
     ...加入需要合并打包的module和依赖


### PR DESCRIPTION
当前展示错乱的README 如下
![image](https://github.com/esastack/esa-cabin/assets/12780186/7d767ed0-78cc-4290-bda6-27f960f1aa36)

修改后，正确的展示如下
![image](https://github.com/esastack/esa-cabin/assets/12780186/5ee8add7-95e3-4e00-9630-c1147968ce9c)
